### PR TITLE
Add `--no-patch` flag to `build-index` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ New features:
 - Show help for each CLI command (#17)
 - Add packages to the search index (#16)
 - Sort search results by popularity (based on number of package reverse dependencies).
+- Add `--no-patch` flag to `build-index` command.
 
 Bugfixes:
 - Fix decoding of kind annotations in `forall`s (#17)

--- a/src/Docs/Search/IndexBuilder.purs
+++ b/src/Docs/Search/IndexBuilder.purs
@@ -88,9 +88,7 @@ run' cfg = do
            <*> parallel (if cfg.noPatch
                          then pure unit
                          else patchDocs cfg)
-           <*> parallel (if cfg.noPatch
-                         then pure unit
-                         else copyAppFile cfg)
+           <*> parallel (copyAppFile cfg)
 
   let countOfDefinitions = Trie.size $ unwrap index
       countOfTypeDefinitions =

--- a/src/Docs/Search/IndexBuilder.purs
+++ b/src/Docs/Search/IndexBuilder.purs
@@ -43,10 +43,12 @@ import Node.Process as Process
 import Web.Bower.PackageMeta (PackageMeta(..))
 
 
-type Config = { docsFiles :: Array String
-              , bowerFiles :: Array String
-              , generatedDocs :: String
-              }
+type Config =
+  { docsFiles :: Array String
+  , bowerFiles :: Array String
+  , generatedDocs :: String
+  , noPatch :: Boolean
+  }
 
 
 run :: Config -> Effect Unit
@@ -83,8 +85,12 @@ run' cfg = do
     ignore <$> parallel (writeIndex cfg index)
            <*> parallel (writeTypeIndex cfg typeIndex)
            <*> parallel (writePackageInfo packageInfo)
-           <*> parallel (patchDocs cfg)
-           <*> parallel (copyAppFile cfg)
+           <*> parallel (if cfg.noPatch
+                         then pure unit
+                         else patchDocs cfg)
+           <*> parallel (if cfg.noPatch
+                         then pure unit
+                         else copyAppFile cfg)
 
   let countOfDefinitions = Trie.size $ unwrap index
       countOfTypeDefinitions =

--- a/src/Docs/Search/Main.purs
+++ b/src/Docs/Search/Main.purs
@@ -14,7 +14,7 @@ import Data.Maybe (Maybe, fromMaybe, optional)
 import Data.Unfoldable (class Unfoldable)
 import Effect (Effect)
 import Effect.Console (log)
-import Options.Applicative (Parser, command, execParser, fullDesc, helper, info, long, metavar, progDesc, strOption, subparser, value, (<**>))
+import Options.Applicative (Parser, command, execParser, flag, fullDesc, help, helper, info, long, metavar, progDesc, strOption, subparser, value, (<**>))
 import Options.Applicative as CA
 
 
@@ -45,6 +45,7 @@ data Commands
     { docsFiles :: Array String
     , bowerFiles :: Array String
     , generatedDocs :: String
+    , noPatch :: Boolean
     }
   | Search
     { docsFiles :: Array String
@@ -92,7 +93,12 @@ buildIndex = ado
    <> value "./generated-docs/"
     )
 
-  in BuildIndex { docsFiles, bowerFiles, generatedDocs }
+  noPatch <- flag false true
+    ( long "no-patch"
+   <> help "Do not patch the HTML docs, only build indices"
+    )
+
+  in BuildIndex { docsFiles, bowerFiles, generatedDocs, noPatch }
 
 
 startInteractive :: Parser Commands


### PR DESCRIPTION
We want to be able to speed up things a bit, if we know that no new modules were added.