### PR TITLE
Consider something a builtin when there's no `sourceSpan`

### DIFF
--- a/src/Docs/Search/Declarations.purs
+++ b/src/Docs/Search/Declarations.purs
@@ -16,7 +16,7 @@ import Data.List as List
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (class Newtype, unwrap, wrap)
 import Data.Search.Trie (Trie, alter)
-import Data.String.CodeUnits (stripPrefix, stripSuffix, toCharArray, indexOf)
+import Data.String.CodeUnits (stripPrefix, stripSuffix, toCharArray)
 import Data.String.Common (split) as String
 import Data.String.Common (toLower)
 import Data.String.Pattern (Pattern(..))
@@ -193,7 +193,7 @@ getLevelAndName DeclExternKind  name = { name, declLevel: KindLevel }
 -- | built-in (guaranteed by the compiler).
 extractPackageName :: ModuleName -> Maybe SourceSpan -> String
 extractPackageName moduleName _
-  | indexOf (Pattern "Prim.") moduleName == Just 0 = "<builtin>"
+  | String.split (Pattern ".") moduleName !! 0 == Just "Prim" = "<builtin>"
 extractPackageName _ Nothing = "<unknown>"
 extractPackageName _ (Just { name }) =
   let dirs = String.split (Pattern "/") name

--- a/src/Docs/Search/Declarations.purs
+++ b/src/Docs/Search/Declarations.purs
@@ -87,7 +87,7 @@ resultsForDeclaration
 resultsForDeclaration scores moduleName indexEntry@(Declaration entry) =
   let { info, title, sourceSpan, comments, children } = entry
       { name, declLevel } = getLevelAndName info.declType title
-      packageName = extractPackageName sourceSpan.name
+      packageName = fromMaybe "builtins" $ map (extractPackageName <<< _.name) sourceSpan
   in case mkInfo declLevel indexEntry of
        Nothing -> mempty
        Just info' ->
@@ -95,7 +95,7 @@ resultsForDeclaration scores moduleName indexEntry@(Declaration entry) =
                                    , comments
                                    , hashAnchor: declLevelToHashAnchor declLevel
                                    , moduleName
-                                   , sourceSpan: Just sourceSpan
+                                   , sourceSpan
                                    , packageName
                                    , score: fromMaybe 0 $ Map.lookup packageName scores
                                    , info: info'

--- a/src/Docs/Search/Declarations.purs
+++ b/src/Docs/Search/Declarations.purs
@@ -1,6 +1,6 @@
 module Docs.Search.Declarations where
 
-import Docs.Search.DocsJson (ChildDeclType(..), ChildDeclaration(..), DeclType(..), Declaration(..), DocsJson(..))
+import Docs.Search.DocsJson (ChildDeclType(..), ChildDeclaration(..), DeclType(..), Declaration(..), DocsJson(..), SourceSpan)
 import Docs.Search.PackageIndex (Scores)
 import Docs.Search.SearchResult (ResultInfo(..), SearchResult(..))
 import Docs.Search.TypeDecoder (Constraint(..), QualifiedName(..), Type(..), Kind, joinForAlls)
@@ -87,7 +87,7 @@ resultsForDeclaration
 resultsForDeclaration scores moduleName indexEntry@(Declaration entry) =
   let { info, title, sourceSpan, comments, children } = entry
       { name, declLevel } = getLevelAndName info.declType title
-      packageName = fromMaybe "builtins" $ map (extractPackageName <<< _.name) sourceSpan
+      packageName = extractPackageName sourceSpan
   in case mkInfo declLevel indexEntry of
        Nothing -> mempty
        Just info' ->
@@ -190,23 +190,18 @@ getLevelAndName DeclExternKind  name = { name, declLevel: KindLevel }
 
 -- | Extract package name from `sourceSpan.name`, which contains path to
 -- | the source file.
-extractPackageName :: String -> String
-extractPackageName name =
-  let chunks = String.split (Pattern "/") name in
-  fromMaybe "<unknown>" $
-  chunks !! 0 >>= \dir ->
-  if dir == ".spago" then
-    chunks !! 1
-  else
-    let
-      bowerComponentsIndex =
-        Array.findIndex (_ == "bower_components") chunks
-    in
-      case bowerComponentsIndex of
-        Just n ->
-          chunks !! (n + 1)
-        Nothing ->
-          Just "<local package>"
+extractPackageName :: Maybe SourceSpan -> String
+extractPackageName Nothing = "<builtin>"
+extractPackageName (Just { name }) =
+  let dirs = String.split (Pattern "/") name
+  in
+    fromMaybe "<local package>" do
+      topLevelDir <- dirs !! 0
+      if topLevelDir == ".spago"
+      then dirs !! 1
+      else do
+        bowerDirIx <- Array.findIndex (_ == "bower_components") dirs
+        dirs !! (bowerDirIx + 1)
 
 
 -- | Extract `SearchResults` from a `ChildDeclaration`.

--- a/src/Docs/Search/DocsJson.purs
+++ b/src/Docs/Search/DocsJson.purs
@@ -46,10 +46,10 @@ newtype Declaration
                          , arguments     :: Maybe (Array TypeArgument)
                          , fundeps       :: Maybe FunDeps
                          }
-               , sourceSpan :: { start :: Array Int
-                               , end :: Array Int
-                               , name :: String
-                               }
+               , sourceSpan :: Maybe { start :: Array Int
+                                     , end :: Array Int
+                                     , name :: String
+                                     }
                , children :: Array ChildDeclaration
                }
 

--- a/src/Docs/Search/DocsJson.purs
+++ b/src/Docs/Search/DocsJson.purs
@@ -33,6 +33,10 @@ instance decodeJsonDocsJson :: DecodeJson DocsJson where
 instance encodeJsonDocsJson :: EncodeJson DocsJson where
   encodeJson = encodeJson <<< unwrap
 
+type SourceSpan = { start :: Array Int
+                  , end :: Array Int
+                  , name :: String
+                  }
 
 newtype Declaration
   = Declaration { title :: String
@@ -46,10 +50,7 @@ newtype Declaration
                          , arguments     :: Maybe (Array TypeArgument)
                          , fundeps       :: Maybe FunDeps
                          }
-               , sourceSpan :: Maybe { start :: Array Int
-                                     , end :: Array Int
-                                     , name :: String
-                                     }
+               , sourceSpan :: Maybe SourceSpan
                , children :: Array ChildDeclaration
                }
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,6 +5,7 @@ import Prelude
 import Docs.Search.TypeDecoder (Constraint(..), FunDep(..), FunDeps(..), Kind(..), QualifiedName(..), Type(..))
 import Test.TypeQuery as TypeQuery
 import Test.IndexBuilder as IndexBuilder
+import Test.Declarations as Declarations
 
 import Test.Extra (assertRight)
 
@@ -26,6 +27,7 @@ mainTest :: TestSuite
 mainTest = do
   TypeQuery.tests
   IndexBuilder.tests
+  Declarations.tests
 
   let mkJson x = unsafePartial $ fromRight $ jsonParser x
   suite "FunDeps decoder" do

--- a/test/Test/Declarations.purs
+++ b/test/Test/Declarations.purs
@@ -1,0 +1,38 @@
+module Test.Declarations where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Docs.Search.Declarations (extractPackageName)
+
+import Test.Unit (TestSuite, suite, test)
+import Test.Unit.Assert as Assert
+
+tests :: TestSuite
+tests = do
+  suite "Declarations" do
+    test "extractPackageName" do
+      Assert.equal "<builtin>" (extractPackageName "Prim" Nothing)
+      Assert.equal "<builtin>" (extractPackageName "Prim.Foo" Nothing)
+      Assert.equal "<builtin>" (extractPackageName "Prim.Foo.Bar" Nothing)
+      Assert.equal "<unknown>" (extractPackageName "Primitive" Nothing)
+      Assert.equal "foo" (extractPackageName "Foo" $
+                    Just { start: []
+                         , end: []
+                         , name: ".spago/foo/src/Foo.purs"
+                         }
+                   )
+      Assert.equal "bar"
+        (extractPackageName "Bar" $
+         Just { start: []
+              , end: []
+              , name: "/path/to/somewhere/bower_components/bar/src/Bar.purs"
+              }
+        )
+      Assert.equal "<local package>"
+        (extractPackageName "Bar" $
+         Just { start: []
+              , end: []
+              , name: "/path/to/somewhere/src/Bar.purs"
+              }
+        )

--- a/test/Test/Declarations.purs
+++ b/test/Test/Declarations.purs
@@ -16,12 +16,13 @@ tests = do
       Assert.equal "<builtin>" (extractPackageName "Prim.Foo" Nothing)
       Assert.equal "<builtin>" (extractPackageName "Prim.Foo.Bar" Nothing)
       Assert.equal "<unknown>" (extractPackageName "Primitive" Nothing)
-      Assert.equal "foo" (extractPackageName "Foo" $
-                    Just { start: []
-                         , end: []
-                         , name: ".spago/foo/src/Foo.purs"
-                         }
-                   )
+      Assert.equal "foo"
+        (extractPackageName "Foo" $
+         Just { start: []
+              , end: []
+              , name: ".spago/foo/src/Foo.purs"
+              }
+        )
       Assert.equal "bar"
         (extractPackageName "Bar" $
          Just { start: []


### PR DESCRIPTION
So I patched `purs` to include Prim modules when generating the `docs.json` files: https://github.com/purescript/purescript/pull/3769

It turns out we were assuming the `sourceSpan` was always there, but it's `null` in the case of builtins (which makes sense), so with this PR we'll consider something a "builtin" when there' no `sourceSpan` available.

Demo:

![image](https://user-images.githubusercontent.com/5480361/72523117-6a054400-385f-11ea-8722-0dbbb013505b.png)
